### PR TITLE
Automatically release on changing package.json version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [main, develop]
 
-
 permissions:
   contents: read
   security-events: write
@@ -91,7 +90,7 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,129 +2,160 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
 
 env:
   NODE_VERSION: '20'
 
 jobs:
+  check-version:
+    name: Check Version
+    runs-on: ubuntu-latest
+    outputs:
+      is_new_version: ${{ steps.check.outputs.is_new_version }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if version is new
+        id: check
+        working-directory: server
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Version $VERSION already tagged."
+            echo "is_new_version=false" >> $GITHUB_OUTPUT
+          else
+            echo "New version detected: $VERSION"
+            echo "is_new_version=true" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          fi
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    needs: check-version
+    if: needs.check-version.outputs.is_new_version == 'true'
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
-    - name: Install dependencies
-      working-directory: server
-      run: npm ci
+      - name: Install dependencies
+        working-directory: server
+        run: npm ci
 
-    - name: Run full test suite
-      working-directory: server
-      run: |
-        npm run typecheck
-        npm run lint
-        npm run test
+      - name: Run full test suite
+        working-directory: server
+        run: |
+          npm run typecheck
+          npm run lint
+          npm run test
 
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: test
+    needs: [check-version, test]
+    if: needs.check-version.outputs.is_new_version == 'true'
     permissions:
       contents: write
       packages: write
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        registry-url: 'https://registry.npmjs.org'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
 
-    - name: Install dependencies
-      working-directory: server
-      run: npm ci
+      - name: Install dependencies
+        working-directory: server
+        run: npm ci
 
-    - name: Build application
-      working-directory: server
-      run: npm run build
+      - name: Build application
+        working-directory: server
+        run: npm run build
 
-    - name: Create mock-data directory
-      working-directory: server
-      run: |
-        mkdir -p mock-data
-        echo '{"orders": [], "products": [], "customers": []}' > mock-data/sample.json
+      - name: Create mock-data directory
+        working-directory: server
+        run: |
+          mkdir -p mock-data
+          echo '{"orders": [], "products": [], "customers": []}' > mock-data/sample.json
 
-    - name: Update package.json version
-      working-directory: server
-      run: |
-        VERSION=${GITHUB_REF#refs/tags/v}
-        npm version $VERSION --no-git-tag-version
+      - name: Create and Push Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.check-version.outputs.version }}"
+          TAG="v$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
 
-    - name: Publish to NPM
-      working-directory: server
-      run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to NPM
+        working-directory: server
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Log in to Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PAT }}
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
 
-    - name: Extract version
-      id: version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./server
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ needs.check-version.outputs.version }}
+          labels: |
+            org.opencontainers.image.title=onX MCP Server
+            org.opencontainers.image.version=${{ needs.check-version.outputs.version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v5
-      with:
-        context: ./server
-        push: true
-        tags: |
-          ghcr.io/${{ github.repository }}:latest
-          ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
-        labels: |
-          org.opencontainers.image.title=onX MCP Server
-          org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
-          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHCR_PAT }}
+        with:
+          tag_name: v${{ needs.check-version.outputs.version }}
+          release_name: Release v${{ needs.check-version.outputs.version }}
+          body: |
+            ## onX MCP Server ${{ needs.check-version.outputs.version }}
 
-    - name: Create GitHub Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GHCR_PAT }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        body: |
-          ## onX MCP Server ${{ steps.version.outputs.VERSION }}
-          
-          ### Installation
-          ```bash
-          npm ci @onx/mcp-server@${{ steps.version.outputs.VERSION }}
-          ```
-          
-          ### Docker
-          ```bash
-          docker pull ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
-          ```
-          
-          ### Changes
-          See [CHANGELOG.md](CHANGELOG.md) for details.
-        draft: false
-        prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+            ### Installation
+            ```bash
+            npm ci @onx/mcp-server@${{ needs.check-version.outputs.version }}
+            ```
+
+            ### Docker
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:${{ needs.check-version.outputs.version }}
+            ```
+
+            ### Changes
+            See [CHANGELOG.md](CHANGELOG.md) for details.
+          draft: false
+          prerelease: ${{ contains(needs.check-version.outputs.version, 'alpha') || contains(needs.check-version.outputs.version, 'beta') || contains(needs.check-version.outputs.version, 'rc') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,8 +143,29 @@ Follow conventional commits:
 
 ## Release Workflow
 
+We follow an automated release process based on the `main` branch:
+
+1.  **Triggering a Release:**
+    -   To publish a new version, you must update the `version` field in `server/package.json` as part of your Pull Request.
+    -   Example: Change `1.0.0` to `1.0.1` (patch), `1.1.0` (minor), or `1.0.0-beta.1` (pre-release).
+
+2.  **Automation:**
+    -   When your PR is merged into `main`, the system checks if the version number is new.
+    -   If it is a new version, the `release` workflow runs automatically to:
+        -   Run a final sanity check (tests/lint).
+        -   Create and push the Git tag (e.g., `v1.0.1`).
+        -   Publish the package to NPM.
+        -   Build and push the Docker image to GHCR.
+        -   Create a GitHub Release entry.
+
+3.  **Pre-releases:**
+    -   Versions with labels like `-alpha`, `-beta`, or `-rc` (e.g., `1.1.0-beta.1`) are automatically marked as "Pre-release" on GitHub.
+
+4.  **When to Bump Version:**
+    -   **No Version Change:** For documentation updates, test improvements, or internal refactoring that doesn't affect the user, **do not** change the version in `package.json`. The changes will simply be merged into `main` and included in the next formal release.
+    -   **Version Change Required:** For bug fixes, new features, or breaking changes that users need immediately.
+
 - Merges to `develop` trigger automated builds
-- Releases are tagged and versioned following semantic versioning
 - Changelogs are generated from commit messages
 
 ## Communication

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cof-org/mcp",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "description": "Commerce Operations Foundation MCP Server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
This PR automates the release process to trigger whenever a PR is merged into `main` with a new version number in `server/package.json`.

## Changes
- **.github/workflows/release.yml**: 
  - Changed trigger from manual tags to `push` on `main`.
  - Added a `check-version` job to detect if the version in `package.json` is new (i.e., does not have a corresponding git tag).
  - Added a `test` job that runs only when a new version is detected.
  - Updated `release` job to automatically create the git tag and publish to NPM/Docker using the detected version.
  - Fixed `prerelease` detection to check the version string (e.g., `1.0.0-beta`) instead of the git branch.

- **CONTRIBUTING.md**: 
  - Updated the "Release Workflow" section to document the new automated process.
  - Added guidelines on when to bump the version (bug fixes/features) vs. when not to (docs/tests).

## How it Works
1. **Update Version**: Bump `version` in `server/package.json` in your PR.
2. **Merge**: Merge the PR into `main`.
3. **Auto-Release**: The workflow detects the new version, tests it, tags it, and publishes it automatically.