### PR TITLE
Align update-order schema to reference server

### DIFF
--- a/schemas/tool-inputs/update-order.json
+++ b/schemas/tool-inputs/update-order.json
@@ -476,7 +476,8 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "minProperties": 1
     }
   },
   "required": [


### PR DESCRIPTION
Aligns JSON Schema with server's Zod validation at server/src/schemas/tool-inputs/update-order.ts:18 which requires at least one update field via Object.keys(data).length === 0 check.

We could go the other way and remove this strict check from the reference server, but since it's deliberately and specifically added aligning to it makes more sense to me.