### PR TITLE
Fix Windows path handling in StructuredLogger

### DIFF
--- a/server/src/adapters/adapter-factory.ts
+++ b/server/src/adapters/adapter-factory.ts
@@ -4,6 +4,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import { pathToFileURL } from 'url';
 import { IFulfillmentAdapter, AdapterConfig, AdapterConstructor, AdapterError } from '../types/index.js';
 import { Logger } from '../utils/logger.js';
 import { MockAdapter } from './mock/mock-adapter.js';
@@ -177,8 +178,8 @@ export class AdapterFactory {
     Logger.info(`Loading local adapter from: ${adapterPath}`);
 
     try {
-      // Dynamically import local file
-      const module = await import(adapterPath);
+      // Dynamically import local file (use file:// URL for Windows compatibility)
+      const module = await import(pathToFileURL(adapterPath).href);
       const exportName = config.exportName || 'default';
       const AdapterClass = module[exportName];
 

--- a/server/src/logging/structured-logger.ts
+++ b/server/src/logging/structured-logger.ts
@@ -6,6 +6,7 @@
 import * as winston from 'winston';
 import * as path from 'path';
 import * as fs from 'fs';
+import { fileURLToPath } from 'url';
 import DailyRotateFile from 'winston-daily-rotate-file';
 import { LogSanitizer } from '../security/log-sanitizer.js';
 
@@ -42,9 +43,9 @@ export class StructuredLogger {
     // Make log directory absolute if it's relative
     if (!path.isAbsolute(logDir)) {
       // Find the server directory (parent of dist when running compiled code)
-      const currentDir = path.dirname(new URL(import.meta.url).pathname);
-      const serverDir = currentDir.includes('/dist/')
-        ? path.resolve(currentDir.split('/dist/')[0])
+      const currentDir = path.dirname(fileURLToPath(import.meta.url));
+      const serverDir = currentDir.includes(`${path.sep}dist${path.sep}`)
+        ? currentDir.split(`${path.sep}dist${path.sep}`)[0]
         : path.resolve(process.cwd(), 'server');
       logDir = path.join(serverDir, logDir);
     }


### PR DESCRIPTION
## Summary

Two Windows path compatibility fixes in the server package:

1. **StructuredLogger** — `new URL(import.meta.url).pathname` returns `/C:/Users/...` on Windows, causing `path.resolve` to produce invalid doubled drive letters (`C:\C:\Users\...\logs`). Replaced with `fileURLToPath(import.meta.url)` and `path.sep` for cross-platform compatibility.

2. **AdapterFactory** — `import(absolutePath)` fails on Windows because Node.js ESM loader interprets the drive letter (e.g. `E:`) as a URL scheme (`ERR_UNSUPPORTED_ESM_URL_SCHEME`). Added `pathToFileURL()` to convert native paths to `file://` URLs before dynamic import.

## Problem

When running `@cof-org/mcp` on Windows (e.g., via Claude Desktop), the server crashes on startup:

**Logger issue:**
```
ENOENT: no such file or directory, mkdir 'C:\C:\Users\...\node_modules\@cof-org\mcp\logs'
```

**Adapter loading issue:**
```
ERR_UNSUPPORTED_ESM_URL_SCHEME: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. Received protocol 'e:'
```

## Fix

- `server/src/logging/structured-logger.ts` — use `fileURLToPath()` + `path.sep`
- `server/src/adapters/adapter-factory.ts` — use `pathToFileURL().href` for dynamic imports

## Test plan

- [ ] Verify server starts on Windows without log directory errors
- [ ] Verify local adapter loading works on Windows
- [ ] Verify server still works on macOS/Linux (no regression)
