### PR TITLE
docs: correct tool count references across documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Initial public release of the Commerce Operations Foundation MCP server
 - TypeScript implementation with MCP SDK
-- Built-in mock adapter and 15 standard tools
+- Built-in mock adapter and 12 standard tools (5 actions + 7 queries)
 - Unit, integration, and e2e test suites
 

--- a/docs/getting-started/for-fulfillment-vendors.md
+++ b/docs/getting-started/for-fulfillment-vendors.md
@@ -1,6 +1,6 @@
 # Getting Started: For Fulfillment Vendors
 
-Build a Commerce Operations Foundation adapter for your fulfillment system using the provided template and the ten tools exposed by the reference server.
+Build a Commerce Operations Foundation adapter for your fulfillment system using the provided template and the twelve tools exposed by the reference server.
 
 ## 1. Set Up the Template
 
@@ -100,7 +100,7 @@ it('creates an order', async () => {
 ## 7. Verification Checklist
 
 - [ ] All lifecycle methods implemented
-- [ ] Ten core tools return properly typed payloads
+- [ ] Twelve core tools return properly typed payloads
 - [ ] Input validation and error codes documented
 - [ ] Adapter options exposed via `ADAPTER_CONFIG`
 - [ ] Automated tests pass (`npm test`)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -37,7 +37,7 @@ See the [Installation Guide](installation.md#claude-desktop-integration) for pla
 
 ## Available Tools
 
-See the [Tools Reference](../standard/tools-reference.md) for documentation of the 10 standard operations.
+See the [Tools Reference](../standard/tools-reference.md) for documentation of the 12 standard operations (5 actions + 7 queries).
 
 ## Adapters
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -128,7 +128,7 @@ You can also send a quick `tools/list` request using stdio:
 echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | node dist/index.js
 ```
 
-The response should contain the ten tools described in the Tools Reference.
+The response should contain the twelve tools described in the Tools Reference.
 
 ## Troubleshooting
 

--- a/docs/introduction/ecosystem-benefits.md
+++ b/docs/introduction/ecosystem-benefits.md
@@ -11,7 +11,7 @@ The Order Network eXchange Standard creates value for every participant in the c
 #### Immediate Capabilities
 - **Instant Commerce Features**: Enable shopping without building commerce infrastructure
 - **Universal Compatibility**: One integration works with all compliant Fulfillment systems
-- **Rich Functionality**: 10 core operations covering order capture, fulfillment, and analytics
+- **Rich Functionality**: 12 core operations covering order capture, fulfillment, returns, and analytics
 - **No Maintenance Burden**: Fulfillment vendors maintain their implementations
 
 #### Competitive Advantages
@@ -234,7 +234,7 @@ Opportunity Cost Analysis:
 
 #### For AI Platforms
 ✓ Enable commerce in < 1 week
-✓ Support the standard 10 operations
+✓ Support the standard 12 operations (5 actions + 7 queries)
 ✓ Zero custom Fulfillment code
 ✓ 99.9% reliability
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -39,7 +39,7 @@ The current specification focuses on request-response patterns. Real-time events
 
 ### How long does implementation take?
 - **Basic implementation**: 1-2 weeks for core tools
-- **Full implementation**: 1-2 months for all 10 shipped tools
+- **Full implementation**: 1-2 months for all 12 shipped tools
 - **Production-ready**: 2-3 months with testing and optimization
 
 ### Do I need to implement every tool?

--- a/docs/specification/mcp-server-spec.md
+++ b/docs/specification/mcp-server-spec.md
@@ -229,7 +229,7 @@ interface ToolRegistry {
 
 ### Standard Tool Set
 
-The reference server implements these ten tools:
+The reference server implements these twelve tools:
 
 #### Action Tools (4 tools)
 
@@ -728,7 +728,7 @@ Compliant implementations MUST pass:
 
 2. **Tool Tests**
 
-   - All 10 standard tools functional
+   - All 12 standard tools functional
    - Parameter validation
    - Error handling
 
@@ -767,7 +767,7 @@ See [examples/](../../examples/) directory for client integration samples.
 ### Version 1.0.0 (August 2025)
 
 - Initial specification release
-- Defined 10 standard tools
+- Defined 12 standard tools (5 actions + 7 queries)
 - Established protocol requirements
 - Set performance targets
 

--- a/docs/standard/tools-reference.md
+++ b/docs/standard/tools-reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-The reference MCP server currently exposes ten fulfillment tools grouped into action and query categories. All tools conform to the `ToolDescription` contract defined in the server source (`server/src/tools`).
+The reference MCP server currently exposes twelve fulfillment tools (5 actions + 7 queries) grouped into action and query categories. All tools conform to the `ToolDescription` contract defined in the server source (`server/src/tools`).
 
 ## Action Tools
 

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -68,8 +68,8 @@ npx vitest tests/unit --grep "AdapterFactory"
 ### Tool System
 
 Tools are defined in `src/tools/` and registered through the explicit list in `registerTools`:
-- **Actions**: `create-sales-order`, `cancel-order`, `update-order`, `fulfill-order`
-- **Queries**: `get-orders`, `get-customers`, `get-products`, `get-product-variants`, `get-inventory`, `get-fulfillments`
+- **Actions**: `create-sales-order`, `cancel-order`, `update-order`, `fulfill-order`, `create-return`
+- **Queries**: `get-orders`, `get-customers`, `get-products`, `get-product-variants`, `get-inventory`, `get-fulfillments`, `get-returns`
 
 All tools extend `BaseTool` which provides:
 - JSON Schema validation via `inputSchema`
@@ -122,7 +122,7 @@ All source uses ES modules with `.js` extensions in imports (required for ES mod
 ## Creating Custom Adapters
 
 1. Implement `IFulfillmentAdapter` interface from `src/types/adapter.ts`
-2. Support the lifecycle hooks plus the ten shipped operations (`createSalesOrder`, `cancelOrder`, `updateOrder`, `fulfillOrder`, `getOrders`, `getCustomers`, `getProducts`, `getProductVariants`, `getInventory`, `getFulfillments`)
+2. Support the lifecycle hooks plus the twelve shipped operations (`createSalesOrder`, `cancelOrder`, `updateOrder`, `fulfillOrder`, `createReturn`, `getOrders`, `getCustomers`, `getProducts`, `getProductVariants`, `getInventory`, `getFulfillments`, `getReturns`)
 
 For built-in adapters:
 1. Create adapter in `src/adapters/your-adapter/`

--- a/server/README.md
+++ b/server/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides standardized access to comme
 
 ## Features
 
-- 10 standardized fulfillment tools covering core order capture, fulfillment, and data queries
+- 12 standardized fulfillment tools (5 actions + 7 queries) covering order capture, fulfillment, returns, and data queries
 - Plug-and-play adapter system for different fulfillment backends
 - Mock adapter for testing and development
 - Full TypeScript implementation with strict type safety


### PR DESCRIPTION
## Summary

Multiple documentation files referenced "10 standard tools" or "15 standard tools."
The actual count is 12 (5 actions + 7 queries). This PR corrects all instances.

Also adds `create-return` and `get-returns` to the tool lists in server/CLAUDE.md
where they were missing (get-product-variants was already listed).

## Files changed (10)

- CHANGELOG.md
- server/README.md
- server/CLAUDE.md
- docs/guides/README.md
- docs/guides/installation.md
- docs/specification/mcp-server-spec.md
- docs/standard/tools-reference.md
- docs/introduction/ecosystem-benefits.md
- docs/resources/faq.md
- docs/getting-started/for-fulfillment-vendors.md