### PR TITLE
fix: add hazmat/export fields to ProductSchema source

### DIFF
--- a/schemas/product.json
+++ b/schemas/product.json
@@ -97,45 +97,31 @@
     },
     "hsCode": {
       "description": "HTS or HS code of the product, up to 14 digits",
-      "type": "string",
-      "value": {
-      }
+      "type": "string"
     },
     "countryOfOrigin": {
       "description": "ISO-2 letter country code",
-      "type": "string",
-      "value": {
-      }
+      "type": "string"
     },
-     "eccn": {
+    "eccn": {
       "description": "Export Control Classification Number, 5 character alphanumeric, required for exports from the USA",
-      "type": "string",
-      "value": {
-      }
+      "type": "string"
     },
-     "unNumber": {
+    "unNumber": {
       "description": "Four digit UN number for hazmat materials identification",
-      "type": "string",
-      "value": {
-      }
+      "type": "string"
     },
-     "unPackingGroup": {
+    "unPackingGroup": {
       "description": "Identifies the degree of danger - values I, II or III",
-      "type": "string",
-      "value": {
-      }
+      "type": "string"
     },
-     "unPackingInstruction": {
+    "unPackingInstruction": {
       "description": "Usually five characters, letters and numbers",
-      "type": "string",
-      "value": {
-      }
+      "type": "string"
     },
     "nmfc": {
-      "description": "National Motor Freigth Classification, used in the US only in lieu of UN codes",
-      "type": "string",
-      "value": {
-      }
+      "description": "National Motor Freight Classification, used in the US only in lieu of UN codes",
+      "type": "string"
     },
     "customFields": {
       "description": "Custom Fields - allows for arbitrary key-value pairs to be added to an entity. Useful for storing any custom data that is not covered by the other fields.",

--- a/server/src/schemas/entities/product.ts
+++ b/server/src/schemas/entities/product.ts
@@ -28,6 +28,15 @@ const ProductCoreSchema = z
     categories: z.array(z.string()),
     options: z.array(ProductOptionSchema).describe('Declares which option dimensions exist for the product'),
     imageURLs: z.array(z.string()).describe('Fallback imagery used when variants omit their own images'),
+    hsCode: z.string().describe('HTS or HS code of the product, up to 14 digits'),
+    countryOfOrigin: z.string().describe('ISO-2 letter country code'),
+    eccn: z
+      .string()
+      .describe('Export Control Classification Number, 5 character alphanumeric, required for exports from the USA'),
+    unNumber: z.string().describe('Four digit UN number for hazmat materials identification'),
+    unPackingGroup: z.string().describe('Identifies the degree of danger - values I, II or III'),
+    unPackingInstruction: z.string().describe('Usually five characters, letters and numbers'),
+    nmfc: z.string().describe('National Motor Freight Classification, used in the US only in lieu of UN codes'),
     customFields: CustomFieldsSchema,
   })
   .partial()


### PR DESCRIPTION
## Why
#25 added these fields directly to `schemas/product.json` by hand, but never updated the Zod source that `generate-schemas.ts` uses to produce that file. Running `npm run generate:json-schemas` on current `develop` silently deletes all 7 fields, since nothing in CI regenerates and diffs the committed schema against the Zod source. Verified this by running the generator before making any change — it removed the fields cleanly, no errors.

## How
Added the same 7 fields to `ProductCoreSchema` (all `z.string()`, optional via the existing `.partial()`), then ran `npm run generate:json-schemas`. Resulting `schemas/product.json` has the same field names/descriptions/types as #25 intended, minus some malformed `"value": {}` artifacts from the original hand-edit (not a valid JSON Schema keyword, inert either way) and one typo fix ("Freigth" → "Freight").

## Testing
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- `npm test` — 224/224 passing